### PR TITLE
if no exif was saved in file, also show `no prompt found`

### DIFF
--- a/pvision.py
+++ b/pvision.py
@@ -55,9 +55,13 @@ def index_directory(directory, ire, parser_manager, existing_images, imagereward
                         positive_prompt = exif.prompts[0][0].value
                     except AttributeError:
                         positive_prompt = "No positive prompt found"
+                    except IndexError:
+                        positive_prompt = "No positive prompt found"
                     try:
                         negative_prompt = exif.prompts[0][1].value
                     except AttributeError:
+                        negative_prompt = "No negative prompt found"
+                    except IndexError:
                         negative_prompt = "No negative prompt found"
                     try:
                         if "ComfyUI" == exif.generator:


### PR DESCRIPTION
When no EXIF field was saved in the image, the App crashed with IndexError.

fixes https://github.com/Automaticism/Promptvision/issues/31